### PR TITLE
Use edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Thin Rust wrapper around some Windows native apis"
 version = "0.3.0"
 authors = ["ElasT0ny <elast0ny00@gmail.com>"]
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2018"
 
 readme = "README.md"
 documentation = "https://docs.rs/win-sys"


### PR DESCRIPTION
There is no reason why this crate has to be edition 2021. In fact
`shared_memory` >=0.12.2 has been reverted to use 2018. Further, if only
edition 2018 is supported, `shared_memory` will not even compile, as this
crate still points to 2021.

https://github.com/elast0ny/shared_memory/issues/80